### PR TITLE
[feature] 주문 취소 시 캐싱된 데이터 삭제

### DIFF
--- a/src/main/java/com/example/shop/admin/service/AdminOrderService.java
+++ b/src/main/java/com/example/shop/admin/service/AdminOrderService.java
@@ -51,13 +51,7 @@ public class AdminOrderService {
             order.changeStatus(OrderStatus.SHIPPING);
 
             // 캐싱된 배송 대기 주문 데이터 삭제
-            String key = getOrderKeyToday();
-            boolean isExist = orderDeliveryRepository.existOrder(key, orderRequest);
-            if (isExist) {
-                orderDeliveryRepository.removeOrderEmail(key, orderRequest);
-            } else {
-                orderDeliveryRepository.removeOrderEmail(getOrderKeyYesterday(), orderRequest);
-            }
+            removeCachingOrder(orderRequest);
         });
 
         // 배송 알림 이메일 보내기
@@ -74,6 +68,22 @@ public class AdminOrderService {
         if (!deliverableToday() && orderDeliveryRepository.existOrder(key, cachedOrder)) {
             orderDeliveryRepository.removeOrderEmail(key, cachedOrder);
             orderDeliveryRepository.addOrderEmail(getCachingDeliveryOrderKey(), cachedOrder);
+        }
+    }
+
+    public void cancelCachingOrder(String email, Long orderId) {
+        OrderDeliveryRequest cachedOrder = new OrderDeliveryRequest(email, orderId);
+        removeCachingOrder(cachedOrder);
+    }
+    
+    // 캐싱된 주문 데이터 Redis에서 삭제
+    private void removeCachingOrder(OrderDeliveryRequest cachedOrder) {
+        String key = getOrderKeyYesterday();
+
+        if (orderDeliveryRepository.existOrder(key, cachedOrder)) {
+            orderDeliveryRepository.removeOrderEmail(key, cachedOrder);
+        } else {
+            orderDeliveryRepository.removeOrderEmail(getOrderKeyToday(), cachedOrder);
         }
     }
 

--- a/src/main/java/com/example/shop/admin/service/AdminOrderService.java
+++ b/src/main/java/com/example/shop/admin/service/AdminOrderService.java
@@ -65,9 +65,9 @@ public class AdminOrderService {
     public void updateCachingOrder(String email, Long orderId) {
         OrderDeliveryRequest cachedOrder = new OrderDeliveryRequest(email, orderId);
         String key = getOrderKeyYesterday();
-        if (!deliverableToday() && orderDeliveryRepository.existOrder(key, cachedOrder)) {
+        if (deliverableToday() && orderDeliveryRepository.existOrder(key, cachedOrder)) {
             orderDeliveryRepository.removeOrderEmail(key, cachedOrder);
-            orderDeliveryRepository.addOrderEmail(getCachingDeliveryOrderKey(), cachedOrder);
+            orderDeliveryRepository.addOrderEmail(getOrderKeyToday(), cachedOrder);
         }
     }
 

--- a/src/main/java/com/example/shop/user/service/OrderService.java
+++ b/src/main/java/com/example/shop/user/service/OrderService.java
@@ -1,6 +1,8 @@
 package com.example.shop.user.service;
 
 import com.example.shop.admin.service.AdminOrderService;
+import com.example.shop.common.dto.OrderListResponse;
+import com.example.shop.common.dto.OrderResponse;
 import com.example.shop.common.dto.PageResponse;
 import com.example.shop.domain.cart.CartDetail;
 import com.example.shop.domain.cart.CartDetailRepository;
@@ -12,10 +14,7 @@ import com.example.shop.domain.user.UserRepository;
 import com.example.shop.global.exception.*;
 import com.example.shop.global.util.SecurityUtil;
 import com.example.shop.user.dto.CreateOrderRequest;
-import com.example.shop.common.dto.OrderListResponse;
-import com.example.shop.common.dto.OrderResponse;
 import com.example.shop.user.dto.UpdateOrderRequest;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -183,6 +182,9 @@ public class OrderService {
 
         // 주문 취소 상태로 변경
         order.changeStatus(OrderStatus.CANCELLED);
+
+        // 캐싱된 주문 데이터 삭제
+        adminOrderService.cancelCachingOrder(user.getEmail(), order.getId());
 
         return new OrderResponse(order);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #80 

## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 주문 취소 시, redis에 저장된 주문 데이터도 삭제된다.
주문이 수정될 때 배송은 다음날에 보내지게 된다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 캐시된 데이터를 삭제하는 코드의 위치가 괜찮은지 확인해주세요!

