### PR TITLE
[refactor] 캐싱하는 값을 orderid가 아닌 ordernumber로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	// mybatis
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 
 	// lombok
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
-
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -35,31 +33,34 @@ dependencies {
 
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	// DB
 	implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
 
 	// Redis 추가
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 
 	// mybatis
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
 
 	// lombok
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/example/shop/admin/dto/OrderDeliveryRequest.java
+++ b/src/main/java/com/example/shop/admin/dto/OrderDeliveryRequest.java
@@ -2,7 +2,6 @@ package com.example.shop.admin.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,6 +16,6 @@ public class OrderDeliveryRequest {
     @NotBlank(message = "공백일 수 없습니다. 이메일을 입력해주세요.")
     private String email;
 
-    @NotNull(message = "공백일 수 없습니다. 주문 번호를 입력해주세요.")
-    private Long orderId;
+    @NotBlank(message = "공백일 수 없습니다. 주문 번호를 입력해주세요.")
+    private String orderNumber;
 }

--- a/src/main/java/com/example/shop/admin/service/AdminOrderService.java
+++ b/src/main/java/com/example/shop/admin/service/AdminOrderService.java
@@ -45,7 +45,7 @@ public class AdminOrderService {
     @Transactional
     public void updateOrderStatusDelivery(List<OrderDeliveryRequest> orderDeliveryList) {
         orderDeliveryList.forEach(orderRequest -> {
-            Order order = orderRepository.findById(orderRequest.getOrderId())
+            Order order = orderRepository.findByOrderNumber(orderRequest.getOrderNumber())
                     .orElseThrow(OrderNotFoundException::new);
 
             order.changeStatus(OrderStatus.SHIPPING);
@@ -58,12 +58,12 @@ public class AdminOrderService {
         orderDeliveryList.forEach(this::sendDeliveryAlertEmail);
     }
 
-    public void cachingDeliveryOrder(String email, Long orderId) {
-        orderDeliveryRepository.addOrderEmail(getCachingDeliveryOrderKey(), new OrderDeliveryRequest(email, orderId));
+    public void cachingDeliveryOrder(String email, String orderNumber) {
+        orderDeliveryRepository.addOrderEmail(getCachingDeliveryOrderKey(), new OrderDeliveryRequest(email, orderNumber));
     }
 
-    public void updateCachingOrder(String email, Long orderId) {
-        OrderDeliveryRequest cachedOrder = new OrderDeliveryRequest(email, orderId);
+    public void updateCachingOrder(String email, String orderNumber) {
+        OrderDeliveryRequest cachedOrder = new OrderDeliveryRequest(email, orderNumber);
         String key = getOrderKeyYesterday();
         if (deliverableToday() && orderDeliveryRepository.existOrder(key, cachedOrder)) {
             orderDeliveryRepository.removeOrderEmail(key, cachedOrder);
@@ -71,8 +71,8 @@ public class AdminOrderService {
         }
     }
 
-    public void cancelCachingOrder(String email, Long orderId) {
-        OrderDeliveryRequest cachedOrder = new OrderDeliveryRequest(email, orderId);
+    public void cancelCachingOrder(String email, String orderNumber) {
+        OrderDeliveryRequest cachedOrder = new OrderDeliveryRequest(email, orderNumber);
         removeCachingOrder(cachedOrder);
     }
     

--- a/src/main/java/com/example/shop/admin/service/OrderDeliveryUtil.java
+++ b/src/main/java/com/example/shop/admin/service/OrderDeliveryUtil.java
@@ -14,11 +14,11 @@ public final class OrderDeliveryUtil {
             DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
 
     static String orderDeliveryTemplate(OrderDeliveryRequest order) {
-        String orderId = order.getOrderId().toString();
+        String orderNumber = order.getOrderNumber();
         String deliveryDate = LocalDate.now().format(KOREAN_DATE_FORMATTER);
 
         Context context = new Context();
-        context.setVariable("orderId", orderId);
+        context.setVariable("orderNumber", orderNumber);
         context.setVariable("deliveryDate", deliveryDate);
         return templateEngine.process("delivery-email", context);
     }

--- a/src/main/java/com/example/shop/user/service/OrderService.java
+++ b/src/main/java/com/example/shop/user/service/OrderService.java
@@ -75,7 +75,7 @@ public class OrderService {
         Order createdOrder = orderRepository.save(order);
         cartDetailRepository.deleteAllByUserId(user.getId());
       
-        adminOrderService.cachingDeliveryOrder(user.getEmail(), order.getId());
+        adminOrderService.cachingDeliveryOrder(user.getEmail(), order.getOrderNumber());
 
         return new OrderResponse(order);
     }
@@ -122,7 +122,7 @@ public class OrderService {
             order.updateTotalPrice();
 
             // 캐싱된 주문 수정
-            adminOrderService.updateCachingOrder(user.getEmail(), order.getId());
+            adminOrderService.updateCachingOrder(user.getEmail(), order.getOrderNumber());
         }
 
         return new OrderResponse(order);
@@ -184,7 +184,7 @@ public class OrderService {
         order.changeStatus(OrderStatus.CANCELLED);
 
         // 캐싱된 주문 데이터 삭제
-        adminOrderService.cancelCachingOrder(user.getEmail(), order.getId());
+        adminOrderService.cancelCachingOrder(user.getEmail(), order.getOrderNumber());
 
         return new OrderResponse(order);
     }

--- a/src/main/resources/mappers/adminMapper.xml
+++ b/src/main/resources/mappers/adminMapper.xml
@@ -40,7 +40,7 @@
     <update id="updateOrderDelivery" parameterType="OrderDeliveryRequest">
         update orders
         set order_status = 'SHIPPING' , updated_at = now()
-        where order_id = #{orderId}
+        where order_number = #{orderNumber}
     </update>
 
 </mapper>

--- a/src/main/resources/templates/delivery-email.html
+++ b/src/main/resources/templates/delivery-email.html
@@ -19,7 +19,7 @@
             <table style="width: 100%; border-collapse: collapse;">
                 <tr>
                     <td style="padding: 10px; border-bottom: 1px solid #ddd; color: #7f8c8d;">주문 번호</td>
-                    <td style="padding: 10px; border-bottom: 1px solid #ddd; color: #34495e;" th:text="${orderId}"></td>
+                    <td style="padding: 10px; border-bottom: 1px solid #ddd; color: #34495e;" th:text="${orderNumber}"></td>
                 </tr>
                 <tr>
                     <td style="padding: 10px; border-bottom: 1px solid #ddd; color: #7f8c8d;">배송 일자</td>

--- a/src/test/java/com/example/shop/admin/dao/OrderDeliveryRepositoryTest.java
+++ b/src/test/java/com/example/shop/admin/dao/OrderDeliveryRepositoryTest.java
@@ -25,7 +25,7 @@ class OrderDeliveryRepositoryTest {
     @BeforeEach
     void setup() {
         for (Long i = 0L; i < 150; i++) {
-            OrderDeliveryRequest order = new OrderDeliveryRequest("test%s@test.com".formatted(i), i*102);
+            OrderDeliveryRequest order = new OrderDeliveryRequest("test%s@test.com".formatted(i), i+"test");
 
             orderDeliveryRepository.addOrderEmail(key, order);
         }
@@ -40,7 +40,7 @@ class OrderDeliveryRepositoryTest {
     @Test
     void addOrderEmail() {
         // given
-        OrderDeliveryRequest request = new OrderDeliveryRequest("testtest@test.com", 999999L);
+        OrderDeliveryRequest request = new OrderDeliveryRequest("testtest@test.com", "99999test");
         // when
         Long addCount = orderDeliveryRepository.addOrderEmail(key, request);
 
@@ -89,7 +89,7 @@ class OrderDeliveryRepositoryTest {
     @Test
     void existOrder() {
         // given
-        OrderDeliveryRequest request = new OrderDeliveryRequest("test50@test.com", 5100L);
+        OrderDeliveryRequest request = new OrderDeliveryRequest("test50@test.com", "50test");
 
         // when & then
         assertThat(orderDeliveryRepository.existOrder(key, request)).isTrue();

--- a/src/test/java/com/example/shop/admin/service/OrderDeliveryUtilTest.java
+++ b/src/test/java/com/example/shop/admin/service/OrderDeliveryUtilTest.java
@@ -16,11 +16,11 @@ class OrderDeliveryUtilTest {
     @Test
     void orderDeliveryTemplateTest() {
         // given
-        OrderDeliveryRequest order = new OrderDeliveryRequest("aaaaaaa@aaaa.com", 13L);
+        OrderDeliveryRequest order = new OrderDeliveryRequest("aaaaaaa@aaaa.com", "주문 번호 test");
         String orderDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
 
         // when & then
         assertThat(orderDeliveryTemplate(order))
-                .contains(order.getOrderId().toString(), orderDate);
+                .contains(order.getOrderNumber(), orderDate);
     }
 }

--- a/src/test/java/com/example/shop/batch/OrderUpdateSenderWriterTest.java
+++ b/src/test/java/com/example/shop/batch/OrderUpdateSenderWriterTest.java
@@ -53,9 +53,9 @@ class OrderUpdateSenderWriterTest {
 
         user = userRepository.save(user);
 
-        for (long i = 335; i <= 568; i++) {
+        for (long i = 1; i <= 532; i++) {
             orderDeliveryRepository.addOrderEmail(getOrderKeyYesterday(),
-                    new OrderDeliveryRequest(user.getEmail(), i));
+                    new OrderDeliveryRequest(user.getEmail(), i+"test"));
         }
     }
 
@@ -75,7 +75,7 @@ class OrderUpdateSenderWriterTest {
         }
 
         SoftAssertions.assertSoftly(softAssertions -> {
-            Order order = orderRepository.findById(orderDeliveryRequestList.get(2).getOrderId())
+            Order order = orderRepository.findByOrderNumber(orderDeliveryRequestList.get(2).getOrderNumber())
                             .orElseThrow(NullPointerException::new);
 
             softAssertions.assertThat(order.getOrderStatus())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

> #83 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 `ex) [feat] ㅇㅇ 기능 추가`
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [ ] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료
- [x] 🏗️ 빌드 성공
- [x] 💯 테스트 통과


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 주문 데이터를 캐싱할 때 orderId 대신 orderNumber 값을 저장
mybatis와 spring 간의 버전이 호환되지 않는 문제 해결


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 다른 수정 사항 없는지 확인해주세요!

